### PR TITLE
migrate internal changes to github

### DIFF
--- a/servicekeeper-adapter/servicekeeper-springboot-adapter/src/test/java/esa/servicekeeper/adapter/springboot/DefaultServiceKeeperAopTest.java
+++ b/servicekeeper-adapter/servicekeeper-springboot-adapter/src/test/java/esa/servicekeeper/adapter/springboot/DefaultServiceKeeperAopTest.java
@@ -45,6 +45,7 @@ class DefaultServiceKeeperAopTest {
 
     @BeforeAll
     static void setUp() {
+        System.setProperty("servicekeeper.configurators.disable", "true");
         ctx = new AnnotationConfigApplicationContext();
         ctx.register(DefaultServiceKeeperAopTest.class);
 

--- a/servicekeeper-configsource/servicekeeper-configsource-common/src/main/java/esa/servicekeeper/configsource/utils/ClassConvertUtils.java
+++ b/servicekeeper-configsource/servicekeeper-configsource-common/src/main/java/esa/servicekeeper/configsource/utils/ClassConvertUtils.java
@@ -81,7 +81,6 @@ public final class ClassConvertUtils {
     public static Class<?> toSingleClass(final String origin) {
         Class<?>[] classes = toClasses(origin);
         if (classes.length == 0) {
-            logger.warn("Failed to convert origin string to class, origin: {}", origin);
             return null;
         }
 

--- a/servicekeeper-core/src/main/java/esa/servicekeeper/core/moats/circuitbreaker/CircuitBreakerMoat.java
+++ b/servicekeeper-core/src/main/java/esa/servicekeeper/core/moats/circuitbreaker/CircuitBreakerMoat.java
@@ -34,6 +34,7 @@ import esa.servicekeeper.core.moats.MoatType;
 import esa.servicekeeper.core.moats.circuitbreaker.predicate.PredicateConfigFilling;
 import esa.servicekeeper.core.moats.circuitbreaker.predicate.PredicateStrategy;
 import esa.servicekeeper.core.utils.LogUtils;
+import esa.servicekeeper.core.utils.TimerLogger;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -54,6 +55,7 @@ public class CircuitBreakerMoat extends AbstractMoat<CircuitBreakerConfig>
 
     private static final CircuitBreakerRegistry REGISTRY = CircuitBreakerRegistry.singleton();
 
+    private final TimerLogger timerLogger = new TimerLogger();
     private final AtomicBoolean shouldDestroy = new AtomicBoolean(false);
     private final LifeCycleType lifeCycleType;
     private final AtomicReference<CircuitBreaker> breaker;
@@ -64,7 +66,7 @@ public class CircuitBreakerMoat extends AbstractMoat<CircuitBreakerConfig>
      * Designed for unit test purpose.
      */
     public CircuitBreakerMoat(MoatConfig config, CircuitBreakerConfig breakerConfig,
-                       CircuitBreakerConfig immutableConfig, PredicateStrategy predicate) {
+                              CircuitBreakerConfig immutableConfig, PredicateStrategy predicate) {
         this(config, breakerConfig, immutableConfig, predicate, null, null);
     }
 
@@ -90,7 +92,7 @@ public class CircuitBreakerMoat extends AbstractMoat<CircuitBreakerConfig>
             } else {
                 // ***  Note: Mustn't modify the log content which is used for keyword alarms.  **
 
-                LogUtils.logCircuitBreakerPeriodically("The circuitBreaker doesn't permit request" +
+                timerLogger.logPeriodically("The circuitBreaker doesn't permit request" +
                         " to through, which name is {} and current state is {}", breaker.name(), breaker.getState());
                 return false;
             }
@@ -102,7 +104,7 @@ public class CircuitBreakerMoat extends AbstractMoat<CircuitBreakerConfig>
                 process(MoatEventImpl.REJECTED_BY_CIRCUIT_BREAKER);
 
                 // ***  Note: Mustn't modify the log content which is used for keyword alarms.  **
-                LogUtils.logCircuitBreakerPeriodically("The circuitBreaker doesn't permit request" +
+                timerLogger.logPeriodically("The circuitBreaker doesn't permit request" +
                         " to through, which name is {} and current state is {}", breaker.name(), breaker.getState());
                 return false;
             }

--- a/servicekeeper-core/src/main/java/esa/servicekeeper/core/moats/concurrentlimit/ConcurrentLimitMoat.java
+++ b/servicekeeper-core/src/main/java/esa/servicekeeper/core/moats/concurrentlimit/ConcurrentLimitMoat.java
@@ -32,6 +32,7 @@ import esa.servicekeeper.core.moats.MoatEventImpl;
 import esa.servicekeeper.core.moats.MoatEventProcessor;
 import esa.servicekeeper.core.moats.MoatType;
 import esa.servicekeeper.core.utils.LogUtils;
+import esa.servicekeeper.core.utils.TimerLogger;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -49,6 +50,7 @@ public class ConcurrentLimitMoat extends AbstractMoat<ConcurrentLimitConfig>
 
     private static final ConcurrentLimiterRegistry REGISTRY = ConcurrentLimiterRegistry.singleton();
 
+    private final TimerLogger timerLogger = new TimerLogger();
     private final AtomicBoolean shouldDestroy = new AtomicBoolean(false);
     private final LifeCycleType lifeCycleType;
     private final ConcurrentLimiter limiter;
@@ -69,7 +71,7 @@ public class ConcurrentLimitMoat extends AbstractMoat<ConcurrentLimitConfig>
                 return true;
             } else {
                 // ***  Note: Mustn't modify the log content which is used for keyword alarms.  **
-                LogUtils.logConcurrentPeriodically("The concurrent exceeds limit {}, which name is {}",
+                timerLogger.logPeriodically("The concurrent exceeds limit {}, which name is {}",
                         limiter.config().getThreshold(), limiter.name());
                 return false;
             }
@@ -81,7 +83,7 @@ public class ConcurrentLimitMoat extends AbstractMoat<ConcurrentLimitConfig>
                 process(MoatEventImpl.REJECTED_BY_CONCURRENT_LIMIT);
                 // ***  Note: Mustn't modify the log content which is used for keyword alarms.  **
 
-                LogUtils.logConcurrentPeriodically("The concurrent exceeds limit {}, which name is {}",
+                timerLogger.logPeriodically("The concurrent exceeds limit {}, which name is {}",
                         limiter.config().getThreshold(), limiter.name());
                 return false;
             }

--- a/servicekeeper-core/src/main/java/esa/servicekeeper/core/moats/ratelimit/RateLimitMoat.java
+++ b/servicekeeper-core/src/main/java/esa/servicekeeper/core/moats/ratelimit/RateLimitMoat.java
@@ -32,6 +32,7 @@ import esa.servicekeeper.core.moats.MoatEventImpl;
 import esa.servicekeeper.core.moats.MoatEventProcessor;
 import esa.servicekeeper.core.moats.MoatType;
 import esa.servicekeeper.core.utils.LogUtils;
+import esa.servicekeeper.core.utils.TimerLogger;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -50,6 +51,7 @@ public class RateLimitMoat extends AbstractMoat<RateLimitConfig> implements
 
     private static final RateLimiterRegistry REGISTRY = RateLimiterRegistry.singleton();
 
+    private final TimerLogger timerLogger = new TimerLogger();
     private final AtomicBoolean shouldDestroy = new AtomicBoolean(false);
     private final LifeCycleType lifeCycleType;
     private final RateLimiter limiter;
@@ -73,7 +75,7 @@ public class RateLimitMoat extends AbstractMoat<RateLimitConfig> implements
                 return true;
             } else {
                 // ***  Note: Mustn't modify the log content which is used for keyword alarms.  **
-                LogUtils.logRatePeriodically("The rate limit exceeds threshold {}, which name is {}",
+                timerLogger.logPeriodically("The rate limit exceeds threshold {}, which name is {}",
                         limiter.config().getLimitForPeriod(), limiter.name());
                 return false;
             }
@@ -85,7 +87,7 @@ public class RateLimitMoat extends AbstractMoat<RateLimitConfig> implements
                 process(MoatEventImpl.REJECTED_BY_RATE_LIMIT);
 
                 // ***  Note: Mustn't modify the log content which is used for keyword alarms.  **
-                LogUtils.logRatePeriodically("The rate limit exceeds threshold {}, which name is {}",
+                timerLogger.logPeriodically("The rate limit exceeds threshold {}, which name is {}",
                         limiter.config().getLimitForPeriod(), limiter.name());
                 return false;
             }

--- a/servicekeeper-core/src/main/java/esa/servicekeeper/core/utils/LogUtils.java
+++ b/servicekeeper-core/src/main/java/esa/servicekeeper/core/utils/LogUtils.java
@@ -20,8 +20,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static java.lang.System.lineSeparator;
 
@@ -29,35 +27,11 @@ public final class LogUtils {
 
     private static final Logger logger = LoggerFactory.getLogger("esa.servicekeeper");
 
-    private static final long LOG_PERIOD = TimeUnit.SECONDS.toNanos(30L);
-    private static final LogUtils INSTANCE = new LogUtils();
-    private final AtomicLong lastRateLogTime = new AtomicLong(0L);
-    private final AtomicLong lastConcurrentLogTime = new AtomicLong(0L);
-    private final AtomicLong lastCircuitBreakerLogTime = new AtomicLong(0L);
-
     private LogUtils() {
     }
 
     public static Logger logger() {
         return logger;
-    }
-
-    public static void logRatePeriodically(String message, Object... objects) {
-        if (canLogRateNow()) {
-            logger.warn(message, objects);
-        }
-    }
-
-    public static void logConcurrentPeriodically(String message, Object... objects) {
-        if (canLogConcurrentNow()) {
-            logger.warn(message, objects);
-        }
-    }
-
-    public static void logCircuitBreakerPeriodically(String message, Object... objects) {
-        if (canLogCircuitBreakerNow()) {
-            logger.warn(message, objects);
-        }
     }
 
     public static String concatValue(List<?> values) {
@@ -95,33 +69,6 @@ public final class LogUtils {
 
         builder.append("]");
         return builder.toString();
-    }
-
-    private static boolean canLogRateNow() {
-        long timestamp = System.nanoTime();
-        if (timestamp - INSTANCE.lastRateLogTime.get() > LOG_PERIOD) {
-            INSTANCE.lastRateLogTime.lazySet(timestamp);
-            return true;
-        }
-        return false;
-    }
-
-    private static boolean canLogConcurrentNow() {
-        long timestamp = System.nanoTime();
-        if (timestamp - INSTANCE.lastConcurrentLogTime.get() > LOG_PERIOD) {
-            INSTANCE.lastConcurrentLogTime.lazySet(timestamp);
-            return true;
-        }
-        return false;
-    }
-
-    private static boolean canLogCircuitBreakerNow() {
-        long timestamp = System.nanoTime();
-        if (timestamp - INSTANCE.lastCircuitBreakerLogTime.get() > LOG_PERIOD) {
-            INSTANCE.lastCircuitBreakerLogTime.lazySet(timestamp);
-            return true;
-        }
-        return false;
     }
 }
 

--- a/servicekeeper-core/src/main/java/esa/servicekeeper/core/utils/TimerLogger.java
+++ b/servicekeeper-core/src/main/java/esa/servicekeeper/core/utils/TimerLogger.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 OPPO ESA Stack Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package esa.servicekeeper.core.utils;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TimerLogger {
+
+    private static final Logger logger = LogUtils.logger();
+    private static final long LOG_PERIOD = TimeUnit.SECONDS.toNanos(30L);
+
+    private final AtomicLong lastLogTime = new AtomicLong(0L);
+
+    public void logPeriodically(String message, Object... objects) {
+        if (canLogRateNow()) {
+            logger.warn(message, objects);
+        }
+    }
+
+    private boolean canLogRateNow() {
+        long timestamp = System.nanoTime();
+        if (timestamp - lastLogTime.get() > LOG_PERIOD) {
+            lastLogTime.set(timestamp);
+            return true;
+        }
+        return false;
+    }
+
+
+}

--- a/servicekeeper-core/src/test/java/esa/servicekeeper/core/executionchain/sync/SyncExecutableTest.java
+++ b/servicekeeper-core/src/test/java/esa/servicekeeper/core/executionchain/sync/SyncExecutableTest.java
@@ -130,16 +130,16 @@ class SyncExecutableTest {
     @Test
     void testCircuitBreakerBySpendTime() {
         final Executable<String> executable = () -> {
-            TimeUnit.MILLISECONDS.sleep(3L);
+            TimeUnit.MILLISECONDS.sleep(100L);
             return "Hello!";
         };
 
         final String name = "testCircuitBreakerBySpendTime";
         List<Moat<?>> moats = Collections.singletonList(new CircuitBreakerMoat(getConfig(name),
-                CircuitBreakerConfig.builder().ringBufferSizeInClosedState(5).build(),
-                null, new PredicateBySpendTime(2)));
+                CircuitBreakerConfig.builder().ringBufferSizeInClosedState(3).build(),
+                null, new PredicateBySpendTime(20)));
         SyncExecutionChain chain = new SyncExecutionChainImpl(moats);
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 3; i++) {
             try {
                 chain.execute(new SyncContext(name), null, executable);
             } catch (Throwable throwable) {

--- a/servicekeeper-core/src/test/java/esa/servicekeeper/core/executionchain/sync/SyncExecutableTest.java
+++ b/servicekeeper-core/src/test/java/esa/servicekeeper/core/executionchain/sync/SyncExecutableTest.java
@@ -130,14 +130,14 @@ class SyncExecutableTest {
     @Test
     void testCircuitBreakerBySpendTime() {
         final Executable<String> executable = () -> {
-            TimeUnit.MILLISECONDS.sleep(100L);
+            TimeUnit.MILLISECONDS.sleep(30L);
             return "Hello!";
         };
 
         final String name = "testCircuitBreakerBySpendTime";
         List<Moat<?>> moats = Collections.singletonList(new CircuitBreakerMoat(getConfig(name),
                 CircuitBreakerConfig.builder().ringBufferSizeInClosedState(3).build(),
-                null, new PredicateBySpendTime(20)));
+                null, new PredicateBySpendTime(2)));
         SyncExecutionChain chain = new SyncExecutionChainImpl(moats);
         for (int i = 0; i < 3; i++) {
             try {


### PR DESCRIPTION
- fix failed to log timing independently
- optimize redundant log
- disable configurators in `DefaultServiceKeeperAopTest` when setup
- fix the execution failure of `SyncExecutableTest#testCircuitBreakerBySpendTime` caused by thread.sleep()'s insufficient precision